### PR TITLE
Remove Android Studio generated Manifest attributes

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,10 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-
-    package="com.pchmn.materialchips">
-
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>
+<manifest
+    package="com.pchmn.materialchips"
+    />

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">MaterialChipsInput</string>
 
     <!-- LetterTileProvider -->
     <!-- All of the possible tile background colors -->


### PR DESCRIPTION
Remove Android Studio generated Manifest attributes causing error with Manifest Merger.

See this post for more information:
https://android.jlelse.eu/2-lines-in-manifest-to-remove-when-sharing-your-android-library-565d4c4af04a