### PR TITLE
Remove allowBackup and supportRtl from manifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
 
     package="com.pchmn.materialchips">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
+    <application android:label="@string/app_name">
 
     </application>
 


### PR DESCRIPTION
Other apps might want to disable the backups or choose not to support RTL.
If this is added explicitly to the manifest, you are forcing people who use your library to allow backups and force them to support RTL.

Replacing these values with the values from another library using `tools:replace="allowBackup,supportsRtl"` shouldn't be the solution.