### PR TITLE
Fix for edittext instance and to add chips programmatically

### DIFF
--- a/library/src/main/java/com/pchmn/materialchips/ChipsInput.java
+++ b/library/src/main/java/com/pchmn/materialchips/ChipsInput.java
@@ -132,7 +132,7 @@ public class ChipsInput extends ScrollViewMaxHeight {
         }
 
         // adapter
-        mChipsAdapter = new ChipsAdapter(mContext, this, mRecyclerView);
+        mChipsAdapter = new ChipsAdapter(mContext, this, mRecyclerView, mHintColor, mTextColor);
         ChipsLayoutManager chipsLayoutManager = ChipsLayoutManager.newBuilder(mContext)
                 .setOrientation(ChipsLayoutManager.HORIZONTAL)
                 .build();
@@ -212,13 +212,7 @@ public class ChipsInput extends ScrollViewMaxHeight {
     }
 
     public ChipsInputEditText getEditText() {
-        ChipsInputEditText editText = new ChipsInputEditText(mContext);
-        if(mHintColor != null)
-            editText.setHintTextColor(mHintColor);
-        if(mTextColor != null)
-            editText.setTextColor(mTextColor);
-
-        return editText;
+        return mChipsAdapter.getmEditText();
     }
 
     public DetailedChipView getDetailedChipView(ChipInterface chip) {

--- a/library/src/main/java/com/pchmn/materialchips/adapter/ChipsAdapter.java
+++ b/library/src/main/java/com/pchmn/materialchips/adapter/ChipsAdapter.java
@@ -1,6 +1,7 @@
 package com.pchmn.materialchips.adapter;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.os.Build;
 import android.support.v7.widget.RecyclerView;
 import android.text.Editable;
@@ -34,20 +35,28 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     private static final String TAG = ChipsAdapter.class.toString();
     private static final int TYPE_EDIT_TEXT = 0;
     private static final int TYPE_ITEM = 1;
+    private ColorStateList mHintColor;
+    private ColorStateList mTextColor;
     private Context mContext;
     private ChipsInput mChipsInput;
     private List<ChipInterface> mChipList = new ArrayList<>();
     private String mHintLabel;
-    private ChipsInputEditText mEditText;
-    private RecyclerView mRecycler;
 
+    private ChipsInputEditText mEditText;
+
+    private RecyclerView mRecycler;
     public ChipsAdapter(Context context, ChipsInput chipsInput, RecyclerView recycler) {
         mContext = context;
         mChipsInput = chipsInput;
         mRecycler = recycler;
         mHintLabel = mChipsInput.getHint();
-        mEditText = mChipsInput.getEditText();
         initEditText();
+    }
+
+    public ChipsAdapter(Context mContext, ChipsInput chipsInput, RecyclerView mRecyclerView, ColorStateList mHintColor, ColorStateList mTextColor) {
+        this(mContext, chipsInput, mRecyclerView);
+        this.mHintColor = mHintColor;
+        this.mTextColor = mTextColor;
     }
 
     private class ItemViewHolder extends RecyclerView.ViewHolder {
@@ -58,8 +67,8 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             super(view);
             chipView = (ChipView) view;
         }
-    }
 
+    }
     private class EditTextViewHolder extends RecyclerView.ViewHolder {
 
         private final EditText editText;
@@ -68,8 +77,8 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             super(view);
             editText = (EditText) view;
         }
-    }
 
+    }
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         if(viewType == TYPE_EDIT_TEXT)
@@ -121,6 +130,13 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     }
 
     private void initEditText() {
+
+        mEditText = new ChipsInputEditText(mContext);
+        if(mHintColor != null)
+            mEditText.setHintTextColor(mHintColor);
+        if(mTextColor != null)
+            mEditText.setTextColor(mTextColor);
+
         mEditText.setLayoutParams(new RelativeLayout.LayoutParams(
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT));
@@ -387,5 +403,9 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         }
 
         return false;
+    }
+
+    public ChipsInputEditText getmEditText() {
+        return mEditText;
     }
 }

--- a/library/src/main/java/com/pchmn/materialchips/views/FilterableListView.java
+++ b/library/src/main/java/com/pchmn/materialchips/views/FilterableListView.java
@@ -14,6 +14,7 @@ import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.animation.AlphaAnimation;
 import android.widget.Filter;
+import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 
 import com.pchmn.materialchips.ChipsInput;
@@ -31,6 +32,7 @@ import butterknife.ButterKnife;
 public class FilterableListView extends RelativeLayout {
 
     private static final String TAG = FilterableListView.class.toString();
+    private FrameLayout frameLayout;
     private Context mContext;
     // list
     @BindView(R2.id.recycler_view) RecyclerView mRecyclerView;
@@ -38,10 +40,16 @@ public class FilterableListView extends RelativeLayout {
     private List<? extends ChipInterface> mFilterableList;
     // others
     private ChipsInput mChipsInput;
+    private ViewGroup rootView;
 
     public FilterableListView(Context context) {
+        this(context, null);
+    }
+
+    public FilterableListView(Context context, ViewGroup layout) {
         super(context);
-        mContext = context;
+        this.mContext = context;
+        this.rootView = layout;
         init();
     }
 
@@ -75,23 +83,25 @@ public class FilterableListView extends RelativeLayout {
             public void onGlobalLayout() {
 
                 // position
-                ViewGroup rootView = (ViewGroup) mChipsInput.getRootView();
+                if(rootView == null){
+                    rootView = (ViewGroup) mChipsInput.getRootView();
+                }
 
                 // size
                 RelativeLayout.LayoutParams layoutParams = new RelativeLayout.LayoutParams(
                         ViewUtil.getWindowWidth(mContext),
-                        ViewGroup.LayoutParams.MATCH_PARENT);
+                        ViewGroup.LayoutParams.WRAP_CONTENT);
 
                 layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
                 layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
 
-                if(mContext.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT){
+                if (mContext.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
                     layoutParams.bottomMargin = ViewUtil.getNavBarHeight(mContext);
                 }
 
-
                 // add view
                 rootView.addView(FilterableListView.this, layoutParams);
+
 
                 // remove the listener:
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
@@ -123,20 +133,7 @@ public class FilterableListView extends RelativeLayout {
     public void fadeIn() {
         if(getVisibility() == VISIBLE)
             return;
-
-        // get visible window (keyboard shown)
-        final View rootView = getRootView();
-        Rect r = new Rect();
-        rootView.getWindowVisibleDisplayFrame(r);
-
-        int[] coord = new int[2];
-        mChipsInput.getLocationInWindow(coord);
-        ViewGroup.MarginLayoutParams layoutParams = (MarginLayoutParams) getLayoutParams();
-        layoutParams.topMargin = coord[1] + mChipsInput.getHeight();
-        // height of the keyboard
-        layoutParams.bottomMargin = rootView.getHeight() - r.bottom;
-        setLayoutParams(layoutParams);
-
+        
         AlphaAnimation anim = new AlphaAnimation(0.0f, 1.0f);
         anim.setDuration(200);
         startAnimation(anim);


### PR DESCRIPTION
Added a better solution to bug #61  and #35 
Now Edittext has only one instance.
It is also initialised on view level, not on adapter.

Chips can also be added programmatically from ChipsInput.