### PR TITLE
Create only one instance of ChipsInputEditText per ChipsInput

### DIFF
--- a/library/src/main/java/com/pchmn/materialchips/ChipsInput.java
+++ b/library/src/main/java/com/pchmn/materialchips/ChipsInput.java
@@ -11,7 +11,6 @@ import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.EditText;
 
 import com.beloo.widget.chipslayoutmanager.ChipsLayoutManager;
 import com.pchmn.materialchips.adapter.ChipsAdapter;
@@ -91,7 +90,7 @@ public class ChipsInput extends ScrollViewMaxHeight {
         ButterKnife.bind(this, rootView);
 
         // attributes
-        if(attrs != null) {
+        if (attrs != null) {
             TypedArray a = mContext.getTheme().obtainStyledAttributes(
                     attrs,
                     R.styleable.ChipsInput,
@@ -125,14 +124,13 @@ public class ChipsInput extends ScrollViewMaxHeight {
                 // filterable list
                 mFilterableListBackgroundColor = a.getColorStateList(R.styleable.ChipsInput_filterable_list_backgroundColor);
                 mFilterableListTextColor = a.getColorStateList(R.styleable.ChipsInput_filterable_list_textColor);
-            }
-            finally {
+            } finally {
                 a.recycle();
             }
         }
 
         // adapter
-        mChipsAdapter = new ChipsAdapter(mContext, this, mRecyclerView);
+        mChipsAdapter = new ChipsAdapter(mContext, this, setupEditText(), mRecyclerView);
         ChipsLayoutManager chipsLayoutManager = ChipsLayoutManager.newBuilder(mContext)
                 .setOrientation(ChipsLayoutManager.HORIZONTAL)
                 .build();
@@ -143,7 +141,7 @@ public class ChipsInput extends ScrollViewMaxHeight {
         // set window callback
         // will hide DetailedOpenView and hide keyboard on touch outside
         Activity activity = ActivityUtil.scanForActivity(mContext);
-        if(activity == null)
+        if (activity == null)
             throw new ClassCastException("android.view.Context cannot be cast to android.app.Activity");
 
         android.view.Window.Callback mCallBack = (activity).getWindow().getCallback();
@@ -212,10 +210,14 @@ public class ChipsInput extends ScrollViewMaxHeight {
     }
 
     public ChipsInputEditText getEditText() {
+        return mChipsAdapter.getEditText();
+    }
+
+    private ChipsInputEditText setupEditText() {
         ChipsInputEditText editText = new ChipsInputEditText(mContext);
-        if(mHintColor != null)
+        if (mHintColor != null)
             editText.setHintTextColor(mHintColor);
-        if(mTextColor != null)
+        if (mTextColor != null)
             editText.setTextColor(mTextColor);
 
         return editText;
@@ -236,25 +238,25 @@ public class ChipsInput extends ScrollViewMaxHeight {
     }
 
     public void onChipAdded(ChipInterface chip, int size) {
-        for(ChipsListener chipsListener: mChipsListenerList) {
+        for (ChipsListener chipsListener : mChipsListenerList) {
             chipsListener.onChipAdded(chip, size);
         }
     }
 
     public void onChipRemoved(ChipInterface chip, int size) {
-        for(ChipsListener chipsListener: mChipsListenerList) {
+        for (ChipsListener chipsListener : mChipsListenerList) {
             chipsListener.onChipRemoved(chip, size);
         }
     }
 
     public void onTextChanged(CharSequence text) {
-        if(mChipsListener != null) {
-            for(ChipsListener chipsListener: mChipsListenerList) {
+        if (mChipsListener != null) {
+            for (ChipsListener chipsListener : mChipsListenerList) {
                 chipsListener.onTextChanged(text);
             }
             // show filterable list
-            if(mFilterableListView != null) {
-                if(text.length() > 0)
+            if (mFilterableListView != null) {
+                if (text.length() > 0)
                     mFilterableListView.filterList(text);
                 else
                     mFilterableListView.fadeOut();
@@ -315,13 +317,13 @@ public class ChipsInput extends ScrollViewMaxHeight {
         this.mChipBackgroundColor = mBackgroundColor;
     }
 
+    public boolean isShowChipDetailed() {
+        return mShowChipDetailed;
+    }
+
     public ChipsInput setShowChipDetailed(boolean mShowChipDetailed) {
         this.mShowChipDetailed = mShowChipDetailed;
         return this;
-    }
-
-    public boolean isShowChipDetailed() {
-        return mShowChipDetailed;
     }
 
     public void setChipDetailedTextColor(ColorStateList mChipDetailedTextColor) {
@@ -336,15 +338,15 @@ public class ChipsInput extends ScrollViewMaxHeight {
         this.mChipDetailedBackgroundColor = mChipDetailedBackgroundColor;
     }
 
+    public List<? extends ChipInterface> getFilterableList() {
+        return mChipList;
+    }
+
     public void setFilterableList(List<? extends ChipInterface> list) {
         mChipList = list;
         mFilterableListView = new FilterableListView(mContext);
         mFilterableListView.build(mChipList, this, mFilterableListBackgroundColor, mFilterableListTextColor);
         mChipsAdapter.setFilterableListView(mFilterableListView);
-    }
-
-    public List<? extends ChipInterface> getFilterableList() {
-        return mChipList;
     }
 
     public ChipValidator getChipValidator() {
@@ -357,7 +359,9 @@ public class ChipsInput extends ScrollViewMaxHeight {
 
     public interface ChipsListener {
         void onChipAdded(ChipInterface chip, int newSize);
+
         void onChipRemoved(ChipInterface chip, int newSize);
+
         void onTextChanged(CharSequence text);
     }
 

--- a/library/src/main/java/com/pchmn/materialchips/adapter/ChipsAdapter.java
+++ b/library/src/main/java/com/pchmn/materialchips/adapter/ChipsAdapter.java
@@ -6,7 +6,6 @@ import android.support.v7.widget.RecyclerView;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -18,10 +17,9 @@ import android.widget.RelativeLayout;
 import com.pchmn.materialchips.ChipView;
 import com.pchmn.materialchips.ChipsInput;
 import com.pchmn.materialchips.model.ChipInterface;
+import com.pchmn.materialchips.util.ViewUtil;
 import com.pchmn.materialchips.views.ChipsInputEditText;
 import com.pchmn.materialchips.views.DetailedChipView;
-import com.pchmn.materialchips.model.Chip;
-import com.pchmn.materialchips.util.ViewUtil;
 import com.pchmn.materialchips.views.FilterableListView;
 
 import java.util.ArrayList;
@@ -41,38 +39,23 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     private ChipsInputEditText mEditText;
     private RecyclerView mRecycler;
 
-    public ChipsAdapter(Context context, ChipsInput chipsInput, RecyclerView recycler) {
+    public ChipsAdapter(Context context, ChipsInput chipsInput,
+                        ChipsInputEditText chipsInputEditText, RecyclerView recycler) {
         mContext = context;
         mChipsInput = chipsInput;
         mRecycler = recycler;
         mHintLabel = mChipsInput.getHint();
-        mEditText = mChipsInput.getEditText();
+        this.mEditText = chipsInputEditText;
         initEditText();
     }
 
-    private class ItemViewHolder extends RecyclerView.ViewHolder {
-
-        private final ChipView chipView;
-
-        ItemViewHolder(View view) {
-            super(view);
-            chipView = (ChipView) view;
-        }
-    }
-
-    private class EditTextViewHolder extends RecyclerView.ViewHolder {
-
-        private final EditText editText;
-
-        EditTextViewHolder(View view) {
-            super(view);
-            editText = (EditText) view;
-        }
+    public ChipsInputEditText getEditText() {
+        return mEditText;
     }
 
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        if(viewType == TYPE_EDIT_TEXT)
+        if (viewType == TYPE_EDIT_TEXT)
             return new EditTextViewHolder(mEditText);
         else
             return new ItemViewHolder(mChipsInput.getChipView());
@@ -82,15 +65,15 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     @Override
     public void onBindViewHolder(final RecyclerView.ViewHolder holder, int position) {
         // edit text
-        if(position == mChipList.size()) {
-            if(mChipList.size() == 0)
+        if (position == mChipList.size()) {
+            if (mChipList.size() == 0)
                 mEditText.setHint(mHintLabel);
 
             // auto fit edit text
             autofitEditText();
         }
         // chip
-        else if(getItemCount() > 1) {
+        else if (getItemCount() > 1) {
             ItemViewHolder itemViewHolder = (ItemViewHolder) holder;
             itemViewHolder.chipView.inflate(getItem(position));
             // handle click
@@ -137,10 +120,10 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             @Override
             public boolean onKey(View v, int keyCode, KeyEvent event) {
                 // backspace
-                if(event.getAction() == KeyEvent.ACTION_DOWN
+                if (event.getAction() == KeyEvent.ACTION_DOWN
                         && event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
                     // remove last chip
-                    if(mChipList.size() > 0 && mEditText.getText().toString().length() == 0)
+                    if (mChipList.size() > 0 && mEditText.getText().toString().length() == 0)
                         removeChip(mChipList.size() - 1);
                 }
                 return false;
@@ -210,7 +193,7 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         });
 
         // show detailed chip
-        if(mChipsInput.isShowChipDetailed()) {
+        if (mChipsInput.isShowChipDetailed()) {
             chipView.setOnChipClicked(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -248,13 +231,13 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
 
         // align left window
-        if(coord[0] <= 0) {
+        if (coord[0] <= 0) {
             layoutParams.leftMargin = 0;
             layoutParams.topMargin = coord[1] - ViewUtil.dpToPx(13);
             detailedChipView.alignLeft();
         }
         // align right
-        else if(coord[0] + ViewUtil.dpToPx(300) > windowWidth + ViewUtil.dpToPx(13)) {
+        else if (coord[0] + ViewUtil.dpToPx(300) > windowWidth + ViewUtil.dpToPx(13)) {
             layoutParams.leftMargin = windowWidth - ViewUtil.dpToPx(300);
             layoutParams.topMargin = coord[1] - ViewUtil.dpToPx(13);
             detailedChipView.alignRight();
@@ -271,12 +254,12 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     }
 
     public void setFilterableListView(FilterableListView filterableListView) {
-        if(mEditText != null)
+        if (mEditText != null)
             mEditText.setFilterableListView(filterableListView);
     }
 
     public void addChip(ChipInterface chip) {
-        if(!listContains(mChipList, chip)) {
+        if (!listContains(mChipList, chip)) {
             mChipList.add(chip);
             // notify listener
             mChipsInput.onChipAdded(chip, mChipList.size());
@@ -371,21 +354,40 @@ public class ChipsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
 
     private boolean listContains(List<ChipInterface> contactList, ChipInterface chip) {
 
-        if(mChipsInput.getChipValidator() != null) {
-            for(ChipInterface item: contactList) {
-                if(mChipsInput.getChipValidator().areEquals(item, chip))
+        if (mChipsInput.getChipValidator() != null) {
+            for (ChipInterface item : contactList) {
+                if (mChipsInput.getChipValidator().areEquals(item, chip))
                     return true;
             }
-        }
-        else {
-            for(ChipInterface item: contactList) {
-                if(chip.getId() != null && chip.getId().equals(item.getId()))
+        } else {
+            for (ChipInterface item : contactList) {
+                if (chip.getId() != null && chip.getId().equals(item.getId()))
                     return true;
-                if(chip.getLabel().equals(item.getLabel()))
+                if (chip.getLabel().equals(item.getLabel()))
                     return true;
             }
         }
 
         return false;
+    }
+
+    private class ItemViewHolder extends RecyclerView.ViewHolder {
+
+        private final ChipView chipView;
+
+        ItemViewHolder(View view) {
+            super(view);
+            chipView = (ChipView) view;
+        }
+    }
+
+    private class EditTextViewHolder extends RecyclerView.ViewHolder {
+
+        private final EditText editText;
+
+        EditTextViewHolder(View view) {
+            super(view);
+            editText = (EditText) view;
+        }
     }
 }

--- a/library/src/main/java/com/pchmn/materialchips/views/FilterableListView.java
+++ b/library/src/main/java/com/pchmn/materialchips/views/FilterableListView.java
@@ -31,9 +31,10 @@ import butterknife.ButterKnife;
 public class FilterableListView extends RelativeLayout {
 
     private static final String TAG = FilterableListView.class.toString();
-    private Context mContext;
     // list
-    @BindView(R2.id.recycler_view) RecyclerView mRecyclerView;
+    @BindView(R2.id.recycler_view)
+    RecyclerView mRecyclerView;
+    private Context mContext;
     private FilterableAdapter mAdapter;
     private List<? extends ChipInterface> mFilterableList;
     // others
@@ -65,7 +66,7 @@ public class FilterableListView extends RelativeLayout {
         // adapter
         mAdapter = new FilterableAdapter(mContext, mRecyclerView, filterableList, chipsInput, backgroundColor, textColor);
         mRecyclerView.setAdapter(mAdapter);
-        if(backgroundColor != null)
+        if (backgroundColor != null)
             mRecyclerView.getBackground().setColorFilter(backgroundColor.getDefaultColor(), PorterDuff.Mode.SRC_ATOP);
 
         // listen to change in the tree
@@ -85,7 +86,7 @@ public class FilterableListView extends RelativeLayout {
                 layoutParams.addRule(RelativeLayout.ALIGN_PARENT_TOP);
                 layoutParams.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
 
-                if(mContext.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT){
+                if (mContext.getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
                     layoutParams.bottomMargin = ViewUtil.getNavBarHeight(mContext);
                 }
 
@@ -109,7 +110,7 @@ public class FilterableListView extends RelativeLayout {
             @Override
             public void onFilterComplete(int count) {
                 // show if there are results
-                if(mAdapter.getItemCount() > 0)
+                if (mAdapter.getItemCount() > 0)
                     fadeIn();
                 else
                     fadeOut();
@@ -121,7 +122,7 @@ public class FilterableListView extends RelativeLayout {
      * Fade in
      */
     public void fadeIn() {
-        if(getVisibility() == VISIBLE)
+        if (getVisibility() == VISIBLE)
             return;
 
         // get visible window (keyboard shown)
@@ -147,7 +148,7 @@ public class FilterableListView extends RelativeLayout {
      * Fade out
      */
     public void fadeOut() {
-        if(getVisibility() == GONE)
+        if (getVisibility() == GONE)
             return;
 
         AlphaAnimation anim = new AlphaAnimation(1.0f, 0.0f);

--- a/sample/src/main/java/com/pchmn/sample/materialchipsinput/ContactListActivity.java
+++ b/sample/src/main/java/com/pchmn/sample/materialchipsinput/ContactListActivity.java
@@ -25,9 +25,12 @@ import butterknife.ButterKnife;
 public class ContactListActivity extends AppCompatActivity {
 
     private static final String TAG = ContactListActivity.class.toString();
-    @BindView(R.id.chips_input) ChipsInput mChipsInput;
-    @BindView(R.id.validate) Button mValidateButton;
-    @BindView(R.id.chip_list) TextView mChipListText;
+    @BindView(R.id.chips_input)
+    ChipsInput mChipsInput;
+    @BindView(R.id.validate)
+    Button mValidateButton;
+    @BindView(R.id.chip_list)
+    TextView mChipListText;
     private List<ContactChip> mContactList;
 
     @Override
@@ -42,7 +45,7 @@ public class ContactListActivity extends AppCompatActivity {
         new RxPermissions(this)
                 .request(Manifest.permission.READ_CONTACTS)
                 .subscribe(granted -> {
-                    if(granted && mContactList.size() == 0)
+                    if (granted && mContactList.size() == 0)
                         getContactList();
 
                 }, err -> {
@@ -74,8 +77,8 @@ public class ContactListActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 String listString = "";
-                for(ContactChip chip: (List<ContactChip>)  mChipsInput.getSelectedChipList()) {
-                    listString += chip.getLabel() + " (" + (chip.getInfo() != null ? chip.getInfo(): "") + ")" + ", ";
+                for (ContactChip chip : (List<ContactChip>) mChipsInput.getSelectedChipList()) {
+                    listString += chip.getLabel() + " (" + (chip.getInfo() != null ? chip.getInfo() : "") + ")" + ", ";
                 }
 
                 mChipListText.setText(listString);
@@ -88,10 +91,10 @@ public class ContactListActivity extends AppCompatActivity {
      * And finally pass the mContactList to the mChipsInput
      */
     private void getContactList() {
-        Cursor phones = this.getContentResolver().query(ContactsContract.Contacts.CONTENT_URI, null,null,null, null);
+        Cursor phones = this.getContentResolver().query(ContactsContract.Contacts.CONTENT_URI, null, null, null, null);
 
         // loop over all contacts
-        if(phones != null) {
+        if (phones != null) {
             while (phones.moveToNext()) {
                 // get contact info
                 String phoneNumber = null;
@@ -99,14 +102,14 @@ public class ContactListActivity extends AppCompatActivity {
                 String name = phones.getString(phones.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME));
                 String avatarUriString = phones.getString(phones.getColumnIndex(ContactsContract.Contacts.PHOTO_THUMBNAIL_URI));
                 Uri avatarUri = null;
-                if(avatarUriString != null)
+                if (avatarUriString != null)
                     avatarUri = Uri.parse(avatarUriString);
 
                 // get phone number
                 if (Integer.parseInt(phones.getString(phones.getColumnIndex(ContactsContract.Contacts.HAS_PHONE_NUMBER))) > 0) {
                     Cursor pCur = this.getContentResolver().query(ContactsContract.CommonDataKinds.Phone.CONTENT_URI,
                             null,
-                            ContactsContract.CommonDataKinds.Phone.CONTACT_ID + " = ?", new String[] { id }, null);
+                            ContactsContract.CommonDataKinds.Phone.CONTACT_ID + " = ?", new String[]{id}, null);
 
                     while (pCur != null && pCur.moveToNext()) {
                         phoneNumber = pCur.getString(pCur.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER));


### PR DESCRIPTION
A call to mChipsInput.getEditText() would create a new instance each time.
The instance held and used by the chips adapter was never returned.