### PR TITLE
Removing white background outline at sides of dark color chips (on darker background)  Fix for Issue #135

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-## [NOT CURRENTLY MAINTAINED]
-
 # MaterialChipsInput
 
 Implementation of Material Design [Chips](https://material.io/guidelines/components/chips.html) component for Android. The library provides two views : [`ChipsInput`](#chipsinput) and [`ChipView`](#chipview).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## [NOT CURRENTLY MAINTAINED]
+
 # MaterialChipsInput
 
 Implementation of Material Design [Chips](https://material.io/guidelines/components/chips.html) component for Android. The library provides two views : [`ChipsInput`](#chipsinput) and [`ChipView`](#chipview).

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.0'
@@ -20,6 +24,10 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 

--- a/library/src/main/res/layout/chip_view.xml
+++ b/library/src/main/res/layout/chip_view.xml
@@ -1,28 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:background="@drawable/bg_chip_view">
-
+    android:layout_height="wrap_content">
+    
     <!-- content -->
     <LinearLayout
         android:id="@+id/content"
-        android:orientation="horizontal"
         android:layout_width="wrap_content"
         android:layout_height="32dp"
+        android:background="@drawable/ripple_chip_view"
         android:clickable="true"
-        android:background="@drawable/ripple_chip_view">
-
+        android:orientation="horizontal">
+        
         <!-- avatar -->
         <de.hdodenhof.circleimageview.CircleImageView
             android:id="@+id/icon"
             android:layout_width="32dp"
             android:layout_height="32dp"
             android:src="@drawable/avatar"
-            android:visibility="gone"/>
-
+            android:visibility="gone" />
+        
         <!-- label -->
         <TextView
             android:id="@+id/label"
@@ -30,20 +28,20 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:paddingLeft="8dp"
-            android:textSize="14sp"
-            android:text="Paulcito"/>
-
+            android:text="Paulcito"
+            android:textSize="14sp" />
+        
         <!-- remove button -->
         <ImageButton
             android:id="@+id/delete_button"
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_gravity="center_vertical"
-            android:src="@drawable/ic_cancel_grey_24dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
             android:layout_marginLeft="4dp"
-            android:layout_marginRight="4dp" />
-
+            android:layout_marginRight="4dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_cancel_grey_24dp" />
+    
     </LinearLayout>
 
 </RelativeLayout>

--- a/sample/src/main/res/layout/activity_chip_examples.xml
+++ b/sample/src/main/res/layout/activity_chip_examples.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="#050510"
     tools:context="com.pchmn.sample.materialchipsinput.MainActivity">
 
     <LinearLayout
@@ -81,7 +82,7 @@
                 android:layout_marginRight="16dp"
                 app:label="Chip 5"
                 app:labelColor="@color/colorPrimary"
-                app:backgroundColor="@android:color/holo_blue_light"
+                app:backgroundColor="#202040"
                 app:deletable="true"
                 app:deleteIconColor="@color/colorPrimary"/>
 
@@ -92,8 +93,7 @@
                 android:layout_marginTop="16dp"
                 app:label="Chip 6"
                 app:labelColor="@android:color/white"
-                app:avatarIcon="@drawable/avatar"
-                app:backgroundColor="@android:color/holo_blue_light"
+                app:backgroundColor="@android:color/holo_blue_dark"
                 app:deletable="true"
                 app:deleteIconColor="@android:color/white" />
 


### PR DESCRIPTION
Please test dark chips on darker background.. chips have white outlines at left and right sides.. Removed it by removing background of Main container(RelativeLayout) of ChipView