### PR TITLE
Removing white background outline at sides of dark color chips (on darker background) Fix for Issue #135

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.0'
@@ -20,6 +24,10 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 25
-        versionCode 9
-        versionName "1.0.8"
+        versionCode 10
+        versionName "1.0.9"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -27,15 +27,15 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.3.0'
-    testCompile 'junit:junit:4.12'
+    compile 'com.android.support:appcompat-v7:25.4.0'
+    testCompile 'junit:junit:4.13'
 
     // recycler
-    compile 'com.android.support:recyclerview-v7:25.3.0'
+    compile 'com.android.support:recyclerview-v7:25.4.0'
     compile 'com.beloo.widget:ChipsLayoutManager:0.3.7@aar'
 
     // circle image view
-    compile 'de.hdodenhof:circleimageview:2.1.0'
+    compile 'de.hdodenhof:circleimageview:3.1.0'
 
     // butter knife
     compile 'com.jakewharton:butterknife:8.5.1'

--- a/library/src/main/res/layout/chip_view.xml
+++ b/library/src/main/res/layout/chip_view.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:background="@drawable/bg_chip_view">
+    android:layout_height="wrap_content">
 
     <!-- content -->
     <LinearLayout

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.pchmn.sample.materialchipsinput"
         minSdkVersion 15
         targetSdkVersion 25
-        versionCode 9
-        versionName "1.0.8"
+        versionCode 10
+        versionName "1.0.9"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -31,13 +31,13 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile project(path: ':library')
+    testCompile 'junit:junit:4.13'
+    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support.constraint:constraint-layout:1.1.3'
+    compile 'io.reactivex.rxjava2:rxjava:2.2.19'
+    compile 'com.tbruyelle.rxpermissions2:rxpermissions:0.9.3@aar'
 
     // butter knife
-    compile 'com.android.support:appcompat-v7:25.3.0'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    compile 'io.reactivex.rxjava2:rxjava:2.0.8'
-    compile 'com.tbruyelle.rxpermissions2:rxpermissions:0.9.3@aar'
     compile 'com.jakewharton:butterknife:8.5.1'
-    testCompile 'junit:junit:4.12'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.5.1'
 }


### PR DESCRIPTION
Please test dark chips on darker background.. chips have white outlines at left and right sides.. Removed it by removing background of Main container(RelativeLayout) of ChipView